### PR TITLE
fix: remove the cgf to run the build.rs only when compiling on unix

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,7 +18,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -28,7 +28,7 @@ jobs:
           components: clippy
 
       - name: Cache .cargo and target
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -29,7 +29,7 @@ jobs:
           components: rustfmt
 
       - name: Cache .cargo and target
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install `cargo-edit`
         run: cargo install cargo-edit
-      
+
       - id: cargo-set-version
         name: Set Version
         run: cargo set-version --bump ${{ inputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -28,7 +28,7 @@ jobs:
           override: true
 
       - name: Cache .cargo and target
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 serde = { version = "1.0.183", features = ["derive"], optional = true}
 thiserror = "1.0"
 
-[target.'cfg(any(target_family = "unix"))'.build-dependencies]
+[target.'cfg(target_family = "unix")'.build-dependencies]
 cc = "1.0.73"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ readme = "README.md"
 serde = { version = "1.0.183", features = ["derive"], optional = true}
 thiserror = "1.0"
 
+[build-dependencies]
+cc = "1.0.73"
+
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = "0.2.101"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly"))'.dependencies]
 libc = "0.2.101"
-
-[target.'cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly"))'.build-dependencies]
-cc = "1.0.73"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libc = "0.2.101"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 serde = { version = "1.0.183", features = ["derive"], optional = true}
 thiserror = "1.0"
 
-[build-dependencies]
+[target.'cfg(any(target_family = "unix"))'.build-dependencies]
 cc = "1.0.73"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(any(target_family = "unix"))]
     {
         use cc::Build;
         use std::path::Path;

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    #[cfg(any(target_family = "unix"))]
+    #[cfg(target_family = "unix")]
     {
         use cc::Build;
         use std::path::Path;

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,4 @@
 fn main() {
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "dragonfly"
-    ))]
     {
         use cc::Build;
         use std::path::Path;

--- a/src/utils/hex.rs
+++ b/src/utils/hex.rs
@@ -11,7 +11,7 @@ impl<'a> HexSlice<'a> {
     }
 }
 
-impl<'a> Display for HexSlice<'a> {
+impl Display for HexSlice<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (index, byte) in self.0.iter().enumerate() {
             if index > 0 {


### PR DESCRIPTION
When I tried to use this lib in a project where I was cross compiling from Linux to Freebsd, I ended up getting linking error because the cfg present in the build.rs doesn't allow the file to be run when compiling on Linux, preventing the Unix ffi from being built. I suggest to remove this cfg, as it allows cross compiling without breaking any other use case, as you check the actual target at runtime inside the build.rs
